### PR TITLE
Fix course card key

### DIFF
--- a/src/common/utils/getCourseKeyString/index.ts
+++ b/src/common/utils/getCourseKeyString/index.ts
@@ -1,0 +1,5 @@
+import { CourseKey } from '@/common/utils/types'
+
+export function getCourseKeyString(course: CourseKey): string {
+  return `${course.courseNo}-${course.studyProgram}-${course.academicYear}-${course.semester}`
+}

--- a/src/common/utils/types.ts
+++ b/src/common/utils/types.ts
@@ -6,3 +6,5 @@ export type ExamClass = Pick<Course, 'courseNo' | 'abbrName' | 'genEdType' | 'mi
     hasOverlap?: boolean
     isHidden: boolean
   }
+
+export type CourseKey = Pick<Course, 'courseNo' | 'studyProgram' | 'academicYear' | 'semester'>

--- a/src/modules/CourseSearch/components/CourseList/components/Courses/index.tsx
+++ b/src/modules/CourseSearch/components/CourseList/components/Courses/index.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@material-ui/core'
 import { Course } from '@thinc-org/chula-courses'
 import React from 'react'
 
+import { getCourseKeyString } from '@/common/utils/getCourseKeyString'
 import { CourseCard } from '@/modules/CourseSearch/components/CourseCard'
 
 export interface CoursesProps {
@@ -19,7 +20,7 @@ export const Courses: React.FC<CoursesProps> = ({ courses, loading }) => {
   return (
     <>
       {courses.map((course) => (
-        <CourseCard key={`${course.courseNo}`} course={course} />
+        <CourseCard key={getCourseKeyString(course)} course={course} />
       ))}
     </>
   )

--- a/src/store/courseCart.ts
+++ b/src/store/courseCart.ts
@@ -6,6 +6,7 @@ import { computedFn } from 'mobx-utils'
 import { CourseGroup } from '@/common/hooks/useCourseGroup/types'
 import { Storage } from '@/common/storage'
 import { StorageKey } from '@/common/storage/constants'
+import { CourseKey } from '@/common/utils/types'
 import { client } from '@/services/apollo'
 import { GetCourseResponse, GetCourseVars, GET_COURSE } from '@/services/apollo/query/getCourse'
 import { GET_COURSE_CART, MODIFY_COURSE_CART } from '@/services/apollo/query/user'
@@ -23,13 +24,6 @@ export interface CourseCartProps {
   shopItems: CourseCartItem[]
   shopItemsByCourseGroup(courseGroup: CourseGroup): CourseCartItem[]
   state: CourseCartState
-}
-
-export interface CourseKey {
-  courseNo: string
-  studyProgram: StudyProgram
-  academicYear: string
-  semester: string
 }
 
 interface CourseCartStoreItem {


### PR DESCRIPTION
This fixes #232

# [Related Task]()

## Link for [Demo](https://dev.cugetreg.com)

- (Optional) Link for [Figma]()
- (Optional) Other [Resources]()

## Why do you do this PR

Previously, the course search page used `course.courseNo` as the key for course card items, causing invalid states in cards to stay. This crashes the app when switching between semesters because the selected section doesn't exist.

## What did you do

Changed the key to be a combination of `courseNo`, `studyProgram`, `academicYear`, and `semester`.

## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [ ] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
