### PR TITLE
Don't warn about a course overlapping itself

### DIFF
--- a/src/modules/Schedule/components/Schedule/utils/index.ts
+++ b/src/modules/Schedule/components/Schedule/utils/index.ts
@@ -43,7 +43,7 @@ function checkOverlap(classes: ScheduleClass[]) {
     for (let j = i + 1; j < classes.length; j++) {
       const a = classes[i]
       const b = classes[j]
-      if (a.position.start < b.position.end) {
+      if (a.courseNo !== b.courseNo && a.position.start < b.position.end) {
         a.hasOverlap = true
         b.hasOverlap = true
         a.overlaps.push(b.abbrName)


### PR DESCRIPTION
# [Related Task]()

## Link for [Demo](https://dev.cugetreg.com)

- (Optional) Link for [Figma]()
- (Optional) Other [Resources]()

## Why do you do this PR

Some courses have duplicated class data, which cause schedule to highlight the course in red.
<img width="1243" alt="Screen Shot 2564-11-08 at 00 27 25" src="https://user-images.githubusercontent.com/8080853/140655203-cbca708b-43a6-48a6-a26b-d348af7f5c64.png">

## What did you do

Ignore overlap from classes in the same course.

## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [ ] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
