### PR TITLE
Fix #245

### DIFF
--- a/src/__mock__/overlap.ts
+++ b/src/__mock__/overlap.ts
@@ -1,7 +1,7 @@
 import { ExamClass } from '@/common/utils/types'
 import { CourseOverlap, CourseOverlapMap, ScheduleClass } from '@/modules/Schedule/components/Schedule/utils'
 
-export const courseTemplate: ScheduleClass = {
+export const courseTemplate: Omit<ScheduleClass, 'classIndex'> = {
   courseNo: '2110316',
   abbrName: 'PROG LANG PRIN',
   genEdType: 'NO',
@@ -44,23 +44,24 @@ export const noOverlap: CourseOverlap = { hasOverlap: false, classes: [], exams:
  * 200010 are overlapping with each 200008 and 200009 twice
  */
 export const mockNonOverlappingCourses: ScheduleClass[] = [
-  { ...courseTemplate, courseNo: '200000' },
-  { ...courseTemplate, courseNo: '200001' },
-  { ...courseTemplate, courseNo: '200002' },
+  { ...courseTemplate, classIndex: 0, courseNo: '200000' },
+  { ...courseTemplate, classIndex: 1, courseNo: '200001' },
+  { ...courseTemplate, classIndex: 2, courseNo: '200002' },
 ]
 export const mockTwoOverlappingCourses_1: ScheduleClass[] = [
-  { ...courseTemplate, courseNo: '200003', hasOverlap: true, overlaps: ['200004'] },
-  { ...courseTemplate, courseNo: '200004', hasOverlap: true, overlaps: ['200003'] },
+  { ...courseTemplate, classIndex: 0, courseNo: '200003', hasOverlap: true, overlaps: ['200004'] },
+  { ...courseTemplate, classIndex: 1, courseNo: '200004', hasOverlap: true, overlaps: ['200003'] },
 ]
 export const mockTwoOverlappingCourses_2: ScheduleClass[] = [
-  { ...courseTemplate, courseNo: '200005', hasOverlap: true, overlaps: ['200006', '200006'] },
-  { ...courseTemplate, courseNo: '200006', hasOverlap: true, overlaps: ['200005', '200005'] },
+  { ...courseTemplate, classIndex: 0, courseNo: '200005', hasOverlap: true, overlaps: ['200006', '200006'] },
+  { ...courseTemplate, classIndex: 1, courseNo: '200006', hasOverlap: true, overlaps: ['200005', '200005'] },
 ]
 export const mockThreeOverlappingCourses: ScheduleClass[] = [
-  { ...courseTemplate, courseNo: '200007', hasOverlap: true, overlaps: ['200009', '200009'] },
-  { ...courseTemplate, courseNo: '200008', hasOverlap: true, overlaps: ['200009', '200009'] },
+  { ...courseTemplate, classIndex: 0, courseNo: '200007', hasOverlap: true, overlaps: ['200009', '200009'] },
+  { ...courseTemplate, classIndex: 1, courseNo: '200008', hasOverlap: true, overlaps: ['200009', '200009'] },
   {
     ...courseTemplate,
+    classIndex: 2,
     courseNo: '200009',
     hasOverlap: true,
     overlaps: ['200007', '200007', '200008', '200008'],

--- a/src/modules/Schedule/components/Schedule/index.tsx
+++ b/src/modules/Schedule/components/Schedule/index.tsx
@@ -27,10 +27,7 @@ function Schedule({ classes }: ScheduleProps) {
       <Header />
       <Gutters />
       {classes.map((scheduleClass) => (
-        <ClassCard
-          key={`${scheduleClass.courseNo}_${scheduleClass.dayOfWeek}_${scheduleClass.position.start}`}
-          scheduleClass={scheduleClass}
-        />
+        <ClassCard key={`${scheduleClass.courseNo}-${scheduleClass.classIndex}`} scheduleClass={scheduleClass} />
       ))}
     </ScheduleTable>
   )

--- a/src/modules/Schedule/components/Schedule/mockClasses.ts
+++ b/src/modules/Schedule/components/Schedule/mockClasses.ts
@@ -11,6 +11,7 @@ const courseTemplate = {
 export const mockClasses: TimetableClass[] = [
   {
     ...courseTemplate,
+    classIndex: 0,
     dayOfWeek: 'MO',
     genEdType: 'HU',
     period: {
@@ -20,6 +21,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 1,
     dayOfWeek: 'MO',
     genEdType: 'NO',
     period: {
@@ -29,6 +31,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 2,
     dayOfWeek: 'MO',
     genEdType: 'NO',
     period: {
@@ -38,6 +41,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 2,
     dayOfWeek: 'TU',
     genEdType: 'SC',
     period: {
@@ -47,6 +51,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 3,
     dayOfWeek: 'WE',
     genEdType: 'NO',
     period: {
@@ -56,6 +61,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 4,
     dayOfWeek: 'WE',
     genEdType: 'NO',
     period: {
@@ -65,6 +71,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 5,
     dayOfWeek: 'WE',
     genEdType: 'NO',
     period: {
@@ -74,6 +81,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 6,
     dayOfWeek: 'TH',
     genEdType: 'NO',
     period: {
@@ -83,6 +91,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 7,
     dayOfWeek: 'FR',
     genEdType: 'SO',
     period: {
@@ -92,6 +101,7 @@ export const mockClasses: TimetableClass[] = [
   },
   {
     ...courseTemplate,
+    classIndex: 8,
     dayOfWeek: 'FR',
     genEdType: 'IN',
     period: {

--- a/src/modules/Schedule/components/Schedule/utils/index.ts
+++ b/src/modules/Schedule/components/Schedule/utils/index.ts
@@ -11,10 +11,12 @@ import { getOverlappingCourses } from './getOverlappingCourses'
 
 export type TimetableClass = Pick<Course, 'courseNo' | 'abbrName' | 'genEdType'> &
   Omit<Class, 'type'> & {
+    classIndex: number
     hasOverlap?: boolean
   }
 
 export type ScheduleClass = Omit<TimetableClass, 'period'> & {
+  classIndex: number
   overlaps: string[]
   position: {
     start: number
@@ -195,9 +197,10 @@ export function useTimetableClasses(shopItems: CourseCartItem[]) {
         return []
       }
       return section.classes.map(
-        (cls): TimetableClass => {
+        (cls, index): TimetableClass => {
           const { dayOfWeek, period, building, room, teachers } = cls
           return {
+            classIndex: index,
             courseNo,
             abbrName,
             genEdType,


### PR DESCRIPTION
# [Related Task]()

## Link for [Demo](https://dev.cugetreg.com)

- (Optional) Link for [Figma]()
- (Optional) Other [Resources]()

## Why do you do this PR

- We previously used course number and location as the key for each class. Turns out there are duplicated classes data from Reg Chula.

## What did you do

- Use section's class index as the key instead

## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [ ] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
