### PR TITLE
Prune dependencies in a separate build stage

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,22 +1,27 @@
-FROM node:14-alpine AS build
+FROM node:14-alpine AS base
 WORKDIR /build
 # Prepare for installing dependencies
 # Utilise Docker cache to save re-installing dependencies if unchanged
 COPY package.json yarn.lock ./
 # Install dependencies
 RUN yarn --frozen-lockfile
+
+FROM base as build
 # Copy the rest files
 COPY . .
 # Build applciation
 RUN yarn build
 
+FROM base as prod-deps
+# Prune unused dependencies
+RUN npm prune --production
+
 FROM node:14-alpine AS production
 ENV NODE_ENV production
 WORKDIR /app
 # Copy only necessary file for running app
-COPY --from=build /build/package.json ./package.json
-# Install prod dependencies
-RUN yarn --prod --frozen-lockfile
+COPY --from=prod-deps /build/package.json ./package.json
+COPY --from=prod-deps /build/node_modules ./node_modules
 COPY --from=build /build/.next ./.next
 COPY --from=build /build/public ./public
 # Expose listening port
@@ -26,4 +31,3 @@ EXPOSE 3000
 USER node
 # Staring script
 CMD yarn start
-


### PR DESCRIPTION
# [Related Task]()

## Link for [Demo](https://github.com/thinc-org/cugetreg-frontend/runs/4188717669?check_suite_focus=true)

- (Optional) Link for [Figma]()
- (Optional) Other [Resources]()

## Why do you do this PR

#251 broke the course detail page

## What did you do

Switch to the old method (running `npm prune`), but move pruning into a new build stage. This allows us to utilize build cache, and simultaneously run build and prune.

## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [ ] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
