### PR TITLE
Feat/footer refinements

### DIFF
--- a/src/common/components/Footer/components/Banner/index.tsx
+++ b/src/common/components/Footer/components/Banner/index.tsx
@@ -13,10 +13,10 @@ import { BannerContainer, PrivacyLink, GithubLink, BannerSubtitle, ResponsiveSta
 export function Banner() {
   const { t } = useTranslation('footer')
   const theme = useTheme()
-  const matches = useMediaQuery(theme.breakpoints.down('sm'))
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <BannerContainer spacing={matches ? 1 : 3}>
+    <BannerContainer spacing={isMobile ? 1 : 3}>
       <Link href="/">
         <Image src={bigLogo} width="172.75" height="56.31" />
       </Link>
@@ -28,7 +28,7 @@ export function Banner() {
           </a>
           <BannerSubtitle>{t('university')}</BannerSubtitle>
         </Stack>
-        <StyledDivider orientation={matches ? 'horizontal' : 'vertical'} />
+        <StyledDivider orientation={'vertical'} />
         <Link href="https://github.com/thinc-org">
           <GithubLink direction="row" alignItems="center">
             <BannerSubtitle>{t('github')}</BannerSubtitle>

--- a/src/common/components/Footer/components/Banner/index.tsx
+++ b/src/common/components/Footer/components/Banner/index.tsx
@@ -29,12 +29,10 @@ export function Banner() {
           <BannerSubtitle>{t('university')}</BannerSubtitle>
         </Stack>
         <StyledDivider orientation={'vertical'} />
-        <Link href="https://github.com/thinc-org">
-          <GithubLink direction="row" alignItems="center">
-            <BannerSubtitle>{t('github')}</BannerSubtitle>
-            <Image src={github} width="20" height="20" />
-          </GithubLink>
-        </Link>
+        <GithubLink href="https://github.com/thinc-org">
+          <BannerSubtitle>{t('github')}</BannerSubtitle>
+          <Image src={github} width="20" height="20" />
+        </GithubLink>
       </ResponsiveStack>
       <Link href="/privacy">
         <PrivacyLink>Privacy Policy</PrivacyLink>

--- a/src/common/components/Footer/components/Banner/index.tsx
+++ b/src/common/components/Footer/components/Banner/index.tsx
@@ -23,7 +23,7 @@ export function Banner() {
 
       <ResponsiveStack>
         <Stack direction="row" alignItems="center" spacing={2}>
-          <a href="https://www.facebook.com/ThailandIncubator">
+          <a href="https://www.facebook.com/ThailandIncubator" style={{ height: 35 }}>
             <Image src={thincLogo} width="78" height="32" />
           </a>
           <BannerSubtitle>{t('university')}</BannerSubtitle>

--- a/src/common/components/Footer/components/Banner/index.tsx
+++ b/src/common/components/Footer/components/Banner/index.tsx
@@ -34,7 +34,7 @@ export function Banner() {
           <Image src={github} width="20" height="20" />
         </GithubLink>
       </ResponsiveStack>
-      <Link href="/privacy">
+      <Link href="/privacy" passHref>
         <PrivacyLink>Privacy Policy</PrivacyLink>
       </Link>
     </BannerContainer>

--- a/src/common/components/Footer/components/Banner/index.tsx
+++ b/src/common/components/Footer/components/Banner/index.tsx
@@ -1,4 +1,4 @@
-import { useMediaQuery, useTheme, Stack } from '@material-ui/core'
+import { Stack } from '@material-ui/core'
 import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
@@ -12,11 +12,9 @@ import { BannerContainer, PrivacyLink, GithubLink, BannerSubtitle, ResponsiveSta
 
 export function Banner() {
   const { t } = useTranslation('footer')
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <BannerContainer spacing={isMobile ? 1 : 3}>
+    <BannerContainer spacing={[1, 3]}>
       <Link href="/">
         <Image src={bigLogo} width="172.75" height="56.31" />
       </Link>

--- a/src/common/components/Footer/components/Banner/index.tsx
+++ b/src/common/components/Footer/components/Banner/index.tsx
@@ -15,32 +15,26 @@ export function Banner() {
   const theme = useTheme()
   const matches = useMediaQuery(theme.breakpoints.down('sm'))
 
-  const showGithub = false
-
   return (
     <BannerContainer spacing={matches ? 1 : 3}>
       <Link href="/">
         <Image src={bigLogo} width="172.75" height="56.31" />
       </Link>
 
-      <ResponsiveStack alignItems="center" spacing={2}>
+      <ResponsiveStack>
         <Stack direction="row" alignItems="center" spacing={2}>
           <a href="https://www.facebook.com/ThailandIncubator">
             <Image src={thincLogo} width="78" height="32" />
           </a>
           <BannerSubtitle>{t('university')}</BannerSubtitle>
         </Stack>
-        {showGithub && (
-          <>
-            <StyledDivider orientation={matches ? 'horizontal' : 'vertical'} />
-            <Link href="https://github.com/thinc-org">
-              <GithubLink direction="row" alignItems="center">
-                <BannerSubtitle>{t('github')}</BannerSubtitle>
-                <Image src={github} width="20" height="20" />
-              </GithubLink>
-            </Link>
-          </>
-        )}
+        <StyledDivider orientation={matches ? 'horizontal' : 'vertical'} />
+        <Link href="https://github.com/thinc-org">
+          <GithubLink direction="row" alignItems="center">
+            <BannerSubtitle>{t('github')}</BannerSubtitle>
+            <Image src={github} width="20" height="20" />
+          </GithubLink>
+        </Link>
       </ResponsiveStack>
       <Link href="/privacy">
         <PrivacyLink>Privacy Policy</PrivacyLink>

--- a/src/common/components/Footer/components/Banner/styled.ts
+++ b/src/common/components/Footer/components/Banner/styled.ts
@@ -7,6 +7,7 @@ export const ResponsiveStack = styled.div`
   align-items: center;
   ${({ theme }) => theme.breakpoints.down('sm')} {
     flex-direction: column;
+    padding: ${({ theme }) => theme.spacing(2, 0)};
   }
 `
 
@@ -36,7 +37,7 @@ export const StyledDivider = styled(Divider)`
   background: ${({ theme }) => theme.palette.primary.contrastText};
   margin: ${({ theme }) => theme.spacing(2)};
   ${({ theme }) => theme.breakpoints.down('sm')} {
-    width: 90%;
+    display: none;
   }
 `
 

--- a/src/common/components/Footer/components/Banner/styled.ts
+++ b/src/common/components/Footer/components/Banner/styled.ts
@@ -23,7 +23,7 @@ export const BannerContainer = styled(Stack)`
   padding: ${({ theme }) => theme.spacing(3)};
 `
 
-export const PrivacyLink = styled.div`
+export const PrivacyLink = styled.a`
   cursor: pointer;
   text-decoration: none;
   color: ${({ theme }) => theme.palette.primary.contrastText};

--- a/src/common/components/Footer/components/Banner/styled.ts
+++ b/src/common/components/Footer/components/Banner/styled.ts
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled'
 import { Divider, Stack, Typography } from '@material-ui/core'
 
-export const ResponsiveStack = styled(Stack)`
+export const ResponsiveStack = styled.div`
+  display: flex;
   flex-direction: row;
+  align-items: center;
   ${({ theme }) => theme.breakpoints.down('sm')} {
     flex-direction: column;
   }
@@ -32,8 +34,8 @@ export const GithubLink = styled(Stack)`
 
 export const StyledDivider = styled(Divider)`
   background: ${({ theme }) => theme.palette.primary.contrastText};
+  margin: ${({ theme }) => theme.spacing(2)};
   ${({ theme }) => theme.breakpoints.down('sm')} {
-    margin: ${({ theme }) => theme.spacing(2, 0)};
     width: 90%;
   }
 `

--- a/src/common/components/Footer/components/Banner/styled.ts
+++ b/src/common/components/Footer/components/Banner/styled.ts
@@ -29,8 +29,13 @@ export const PrivacyLink = styled.div`
   color: ${({ theme }) => theme.palette.primary.contrastText};
 `
 
-export const GithubLink = styled(Stack)`
-  cursor: pointer;
+export const GithubLink = styled.a`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  text-decoration: none;
+  color: ${({ theme }) => theme.palette.primary.contrastText};
 `
 
 export const StyledDivider = styled(Divider)`


### PR DESCRIPTION
## Why did you create this PR
- we've open our repo to the public, so let's enable the button
- Thinc logo was unaligned
<img width="286" alt="Screen Shot 2564-11-12 at 19 59 39" src="https://user-images.githubusercontent.com/8080853/141471074-c262e6e8-c4c5-47ae-ba3e-a464ab2a822f.png">

## What did you do
- enabled GitHub button
- aligned Thinc logo and refined the spacing
- converted "fake" links to use actual `a` tags

## Demo
[https://dev.cugetreg.com](https://dev.cugetreg.com)

Desktop:
<img width="1666" alt="Screen Shot 2564-11-12 at 20 01 34" src="https://user-images.githubusercontent.com/8080853/141471296-eef12798-22f0-4a17-a0e0-2bbee6c8776d.png">

Mobile:
<img width="373" alt="Screen Shot 2564-11-12 at 20 01 57" src="https://user-images.githubusercontent.com/8080853/141471333-28bb06b1-8b4b-471f-bd06-7b440b818a4a.png">

## Checklist
- [x] Deploy a demo
<!-- - [ ] Check browsers compatibility -->
<!-- - [ ] Wrote coverage tests -->

<!-- 
## Related links
-
-->
 
