### PR TITLE
Add Course Recommendation FOR REAL THIS TIME

### DIFF
--- a/src/modules/CourseSearch/components/RecommendationText/index.tsx
+++ b/src/modules/CourseSearch/components/RecommendationText/index.tsx
@@ -107,6 +107,7 @@ export const RecommendationText: React.FC<{variant: string}> = observer((props: 
               elementId={`RecommendationLink/${variant}/${course.key.semesterKey.studyProgram}/courses/${course.key.courseNo}`}
             >
               <RecommendationItem
+                id={`RecommendationLink/${variant}/${course.key.semesterKey.studyProgram}/courses/${course.key.courseNo}`}
                 target="_blank"
                 href={`/${course.key.semesterKey.studyProgram}/courses/${course.key.courseNo}`}
               >

--- a/src/modules/CourseSearch/components/RecommendationText/index.tsx
+++ b/src/modules/CourseSearch/components/RecommendationText/index.tsx
@@ -1,0 +1,122 @@
+import { gql, useQuery } from '@apollo/client'
+import styled from '@emotion/styled'
+import { Link, Typography } from '@mui/material'
+import { Box } from '@mui/system'
+import { observer } from 'mobx-react'
+import { useEffect } from 'react'
+
+import { Analytics } from '@/common/context/Analytics/components/Analytics'
+import { useCourseGroup } from '@/common/hooks/useCourseGroup'
+import { collectLogEvent } from '@/services/logging'
+import { courseCartStore } from '@/store'
+
+const RecommendationItem = styled(Link)`
+  color: #211091;
+  margin-left: 1em;
+`
+
+const RECOMMENDATION_QUERY = gql`
+  query RecommendCourseText($req: CourseRecommendationRequest!) {
+    recommend(req: $req) {
+      course {
+        courseNameEn
+        key {
+          semesterKey {
+            semester
+            studyProgram
+          }
+          courseNo
+        }
+      }
+    }
+  }
+`
+
+interface SemesterKey {
+  studyProgram: string
+  semester: string
+  academicYear: string
+}
+
+interface CourseKey {
+  semesterKey: SemesterKey
+  courseNo: string
+}
+
+interface RecommendationParam {
+  req: {
+    variant: string
+    semesterKey: SemesterKey
+    selectedCourse: CourseKey[]
+  }
+}
+
+interface RecommendationResponse {
+  recommend: {
+    course: {
+      courseNameEn: string
+      key: CourseKey
+    }[]
+  }
+}
+
+export const RecommendationText = observer((props: { variant: string }) => {
+  const variant = props.variant
+  const courseGroup = useCourseGroup()
+  const { data } = useQuery<RecommendationResponse, RecommendationParam>(RECOMMENDATION_QUERY, {
+    variables: {
+      req: {
+        variant,
+        semesterKey: courseGroup,
+        selectedCourse: courseCartStore.shopItems.map((item) => ({
+          courseNo: item.courseNo,
+          semesterKey: {
+            semester: item.semester,
+            studyProgram: item.studyProgram,
+            academicYear: item.academicYear,
+          },
+        })),
+      },
+    },
+  })
+
+  const visibleRecommendation = data && data.recommend.course.length > 0 ? data.recommend.course.slice(0, 6) : null
+
+  useEffect(() => {
+    const visibleRecommendation = data && data.recommend.course.length > 0 ? data.recommend.course.slice(0, 6) : null
+    collectLogEvent({
+      kind: 'track',
+      message: 'displayed recommendation',
+      additionalData: {
+        variant,
+        display: JSON.stringify(visibleRecommendation),
+      },
+    })
+  }, [data, variant])
+
+  if (visibleRecommendation) {
+    return (
+      <Box marginBottom="1em">
+        <Typography variant="body2" color="#8170F1">
+          คุณอาจสนใจวิชาเหล่านี้
+          {visibleRecommendation.map((course) => (
+            <Analytics
+              key={course.key.courseNo}
+              elementName="RecommendationLink"
+              elementId={`RecommendationLink/${variant}/${course.key.semesterKey.studyProgram}/courses/${course.key.courseNo}`}
+            >
+              <RecommendationItem
+                target="_blank"
+                href={`/${course.key.semesterKey.studyProgram}/courses/${course.key.courseNo}`}
+              >
+                {course.key.courseNo} {course.courseNameEn}
+              </RecommendationItem>
+            </Analytics>
+          ))}
+        </Typography>
+      </Box>
+    )
+  } else {
+    return null
+  }
+})

--- a/src/modules/CourseSearch/components/RecommendationText/index.tsx
+++ b/src/modules/CourseSearch/components/RecommendationText/index.tsx
@@ -2,8 +2,9 @@ import { gql, useQuery } from '@apollo/client'
 import styled from '@emotion/styled'
 import { Link, Typography } from '@mui/material'
 import { Box } from '@mui/system'
+import useGoogleOptimize from '@react-hook/google-optimize'
 import { observer } from 'mobx-react'
-import { useEffect } from 'react'
+import { FC, useEffect } from 'react'
 
 import { Analytics } from '@/common/context/Analytics/components/Analytics'
 import { useCourseGroup } from '@/common/hooks/useCourseGroup'
@@ -60,7 +61,7 @@ interface RecommendationResponse {
   }
 }
 
-export const RecommendationText = observer((props: { variant: string }) => {
+export const RecommendationText: React.FC<{variant: string}> = observer((props: { variant: string })  => {
   const variant = props.variant
   const courseGroup = useCourseGroup()
   const { data } = useQuery<RecommendationResponse, RecommendationParam>(RECOMMENDATION_QUERY, {
@@ -117,6 +118,15 @@ export const RecommendationText = observer((props: { variant: string }) => {
       </Box>
     )
   } else {
-    return null
+    return <></>
   }
 })
+
+export default function ExperimentalRecommendationText() {
+  const recommendationVariant = useGoogleOptimize('KZLly-4DQ1CHxWOlVwOJ4g', ['NONE', 'RANDOM', 'COSINE']) || 'NONE'
+  console.log('Variant ', recommendationVariant)
+  if (recommendationVariant !== 'NONE')
+    return <RecommendationText variant={recommendationVariant} /> 
+  else
+    return <></>
+}

--- a/src/modules/CourseSearch/index.tsx
+++ b/src/modules/CourseSearch/index.tsx
@@ -1,5 +1,6 @@
 import { Hidden, Typography } from '@mui/material'
 import useGoogleOptimize from '@react-hook/google-optimize'
+import dynamic from 'next/dynamic'
 
 import { Analytics } from '@/common/context/Analytics/components/Analytics'
 import { FILTER_BUTTON, SELECTED_COURSES_BUTTON, OPEN_SHOPPING_CART_BUTTON } from '@/common/context/Analytics/constants'
@@ -16,9 +17,10 @@ import { CourseSearchProvider } from './context/CourseSearch'
 import { useCourseSearchPage } from './hooks/useCourseSearchPage'
 import { Container, Stack, TitleStack, StickyStack } from './styled'
 
+const ExperimentalRecommendationText = dynamic(() => import('@/modules/CourseSearch/components/RecommendationText'), { ssr: false })
+
 export function CourseSearchPage() {
   const { openFilterBar, toggleFilterBar, onOpen, handleCloseFilterBar } = useCourseSearchPage()
-  const recommendationVariant = useGoogleOptimize('KZLly-4DQ1CHxWOlVwOJ4g', ['NONE', 'RANDOM', 'COSINE']) || 'NONE'
 
   return (
     <Container>
@@ -46,7 +48,7 @@ export function CourseSearchPage() {
         <TagList />
       </StickyStack>
       <NoTagListLayout />
-      {recommendationVariant !== 'NONE' && <RecommendationText variant={recommendationVariant} />}
+      <ExperimentalRecommendationText />
       <Stack spacing={3} direction="row">
         <CourseList />
         <FilterSection open={openFilterBar} handleClose={handleCloseFilterBar} />

--- a/src/modules/CourseSearch/index.tsx
+++ b/src/modules/CourseSearch/index.tsx
@@ -1,4 +1,5 @@
 import { Hidden, Typography } from '@mui/material'
+import useGoogleOptimize from '@react-hook/google-optimize'
 
 import { Analytics } from '@/common/context/Analytics/components/Analytics'
 import { FILTER_BUTTON, SELECTED_COURSES_BUTTON, OPEN_SHOPPING_CART_BUTTON } from '@/common/context/Analytics/constants'
@@ -6,6 +7,7 @@ import { PageMeta } from '@/components/PageMeta'
 import { CourseList } from '@/modules/CourseSearch/components/CourseList'
 import { FilterIconButton } from '@/modules/CourseSearch/components/FilterIconButton'
 import { FilterSection } from '@/modules/CourseSearch/components/FilterSection'
+import { RecommendationText } from '@/modules/CourseSearch/components/RecommendationText'
 import { SearchField } from '@/modules/CourseSearch/components/SearchField'
 import { SelectedCoursesButton } from '@/modules/CourseSearch/components/SelectedCoursesButton'
 import { NoTagListLayout, TagList } from '@/modules/CourseSearch/components/TagList'
@@ -16,6 +18,7 @@ import { Container, Stack, TitleStack, StickyStack } from './styled'
 
 export function CourseSearchPage() {
   const { openFilterBar, toggleFilterBar, onOpen, handleCloseFilterBar } = useCourseSearchPage()
+  const recommendationVariant = useGoogleOptimize('KZLly-4DQ1CHxWOlVwOJ4g', ['NONE', 'RANDOM', 'COSINE']) || 'NONE'
 
   return (
     <Container>
@@ -43,6 +46,7 @@ export function CourseSearchPage() {
         <TagList />
       </StickyStack>
       <NoTagListLayout />
+      {recommendationVariant !== 'NONE' && <RecommendationText variant={recommendationVariant} />}
       <Stack spacing={3} direction="row">
         <CourseList />
         <FilterSection open={openFilterBar} handleClose={handleCloseFilterBar} />


### PR DESCRIPTION
## Why did you create this PR
- By using course recommendation, The user can just enter a couple course, then the rest of their departmental courses should hopefully show up.

## What did you do
- Add course recommendation text below the search bar

## Demo
[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist
- [x] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

## Testing Procedure

Since this PR uses Google Optimize to deploy these variant:

1. NONE: No Recommendation
2. RANDOM: Random Recommendation
3.  COSINE: Recommendation base on user's course cart (see New's Notebook)

You have to preview experiment (in case that you ends up in NONE type)

1. Go to https://optimize.google.com/optimize/home/#/accounts/4704418124/containers/14730343/experiments/37
2. Click preview on any variant EXCEPT NONE.
3. You suppose to see the recommendation (COSINE would require that you add some course in course cart first
