### PR TITLE
fix: ChulaCharas font vowels and tone marks positioning

### DIFF
--- a/src/configs/theme/typography.ts
+++ b/src/configs/theme/typography.ts
@@ -56,6 +56,7 @@ const baseTypographyVariantOptions: Record<TypographyVariant, TypographyStyleOpt
     fontFamily: 'ChulaCharasNew',
     fontSize: 16,
     fontWeight: 400,
+    fontFeatureSettings: '"liga" on',
   },
   body2: {
     letterSpacing: 0.25,
@@ -63,6 +64,7 @@ const baseTypographyVariantOptions: Record<TypographyVariant, TypographyStyleOpt
     fontFamily: 'ChulaCharasNew',
     fontSize: 14,
     fontWeight: 400,
+    fontFeatureSettings: '"liga" on',
   },
   button: {
     letterSpacing: 1.25,


### PR DESCRIPTION
## Why did you create this PR
- This PR fixes ChulaCharas font vowels and tone marks positioning.

## What did you do
- Force enable ligature (`liga`) which is a workaround that majority of Thai fonts use to positioning vowels and tone marks. (It is enabled by default but setting `letterSpacing` disabled it)
- Note that another font (Prompt) doesn't have this problem since it uses a newer (and straightforward) OpenType feature.

## Demo


https://user-images.githubusercontent.com/30551284/154838856-875079d1-11e0-478b-b723-f24c5596abf6.mp4



## Checklist
- [x] Deploy a demo
- [x] Check browsers compatibility
- [ ] Wrote coverage tests

<!-- 
## Related links
-
-->
 
