### PR TITLE
Fix RichTextEditor delete backward behavior for Thai script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-icons": "^4.2.0",
     "react-loading": "^2.0.3",
     "react-measure": "^2.5.2",
-    "slate": "^0.81.1-20225844048",
+    "slate": "^0.81.1",
     "slate-history": "^0.66.0",
     "slate-hyperscript": "^0.67.0",
     "slate-react": "0.72.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-icons": "^4.2.0",
     "react-loading": "^2.0.3",
     "react-measure": "^2.5.2",
-    "slate": "^0.72.0",
+    "slate": "^0.81.1-20225844048",
     "slate-history": "^0.66.0",
     "slate-hyperscript": "^0.67.0",
     "slate-react": "0.72.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12024,10 +12024,10 @@ slate-react@0.72.1:
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-slate@^0.81.1-20225844048:
-  version "0.81.1-2022511151651"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.81.1-2022511151651.tgz#111ea4e3c083bd32b1dbf145f8ef66074ac87aad"
-  integrity sha512-h44mKOfOuc3AszylsqCnWjZJfS7dCA2+wRBkoyg7RteQeU6Ab/5FxopnXOIcrd6xCQdX7KULR1LbUk2Ca1iXpQ==
+slate@^0.81.1:
+  version "0.81.1"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.81.1.tgz#98d9f87b1ea2d648bfbab2739dcb1ba897f3bba0"
+  integrity sha512-nmqphQb2qnlJpPMKsoxeWShpa+pOlKfy6XVdmlTuOtgWeGethM6SMPSRTrhh5UF/G+3/IoXhfbKF7o3iDZCbWw==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12024,10 +12024,10 @@ slate-react@0.72.1:
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-slate@^0.72.0:
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.72.0.tgz#509b4fd06a13eab6c19ea28aa4f1848064e4c61b"
-  integrity sha512-PdyMSxsv6ZOeoPp/tKb3mCfn7jWdtnavKzzuVrTYbydOIubYq60N9D3kJRcvR7Z86kxIOzu1ZXB8vsUzy30/vg==
+slate@^0.81.1-20225844048:
+  version "0.81.1-2022511151651"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.81.1-2022511151651.tgz#111ea4e3c083bd32b1dbf145f8ef66074ac87aad"
+  integrity sha512-h44mKOfOuc3AszylsqCnWjZJfS7dCA2+wRBkoyg7RteQeU6Ab/5FxopnXOIcrd6xCQdX7KULR1LbUk2Ca1iXpQ==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"


### PR DESCRIPTION
## Why did you create this PR
- This PR fixes the RichTextEditor delete backward behavior for Thai script where deleting N character(s) backward should delete N code point(s) instead of an entire grapheme cluster.

## What did you do
- The `Transform.delete` method of Slate (the package that Plate built on top of) was modified so that it insert back code point of Thai script that should remain upon delete backward.
- As far as I concerned, there is no breaking change to upgrade from 0.72.0 to 0.81.1, per the [CHANGELOG](https://github.com/ianstormtaylor/slate/blob/main/packages/slate/CHANGELOG.md)

## Demo
Before:

https://user-images.githubusercontent.com/30551284/173242116-d0af41d4-a2b8-4676-9d98-93455d70d65a.mp4


After:

https://user-images.githubusercontent.com/30551284/173242124-c7f9b507-24d4-49ee-bbde-2af0d4dcf350.mp4



## Checklist
- [ ] Deploy a demo (will wait for the maintainer to publish v0.81.1 to NPM first.)
- [x] Check browsers compatibility
- [x] Wrote coverage tests (in upstream repo)

## Related links
- https://github.com/ianstormtaylor/slate/pull/5015

 
