### PR TITLE
[Fix] Cookie banner reappearing

### DIFF
--- a/apps/cugetreg-web/src/common/components/CookieBanner/components/CookieSettings/index.tsx
+++ b/apps/cugetreg-web/src/common/components/CookieBanner/components/CookieSettings/index.tsx
@@ -12,6 +12,7 @@ interface CookieSettingsProps extends DialogProps {
   consents?: Consents
   setConsents: (consents: Consents) => void
   submitConsents: () => void
+  onCloseBanner: () => void
 }
 
 const Transition = forwardRef(function Transition(
@@ -28,17 +29,25 @@ export const CookieSettings = ({
   setConsents,
   submitConsents,
   onClose,
+  onCloseBanner,
   ...props
 }: CookieSettingsProps) => {
-  const handleConsentChange =
-    (mode: ConsentMode): ChangeEventHandler<HTMLInputElement> =>
-    (event) => {
-      setConsents({ ...consents, [mode]: event.target.checked })
-    }
+  const onConsentChange = (mode: ConsentMode) => (newValue: boolean) => {
+    setConsents({ ...consents, [mode]: newValue })
+  }
+
+  const analyticsStorageChecked = consents?.[ConsentMode.ANALYTICS_STORAGE] ?? false
+  const onAnalyticsStorageChange = onConsentChange(ConsentMode.ANALYTICS_STORAGE)
 
   const handleClose: MouseEventHandler = (event) => {
-    submitConsents()
     onClose?.(event, 'escapeKeyDown')
+  }
+
+  const handleConfirm: MouseEventHandler = (event) => {
+    onAnalyticsStorageChange(analyticsStorageChecked)
+    handleClose(event)
+    submitConsents()
+    onCloseBanner()
   }
 
   return (
@@ -69,14 +78,14 @@ export const CookieSettings = ({
         </SettingBlock> */}
         <SettingBlock
           title="คุกกี้เพื่อการวิเคราะห์"
-          onChange={handleConsentChange(ConsentMode.ANALYTICS_STORAGE)}
-          checked={consents?.[ConsentMode.ANALYTICS_STORAGE] ?? false}
+          onChange={(e) => onAnalyticsStorageChange(e.target.checked)}
+          checked={analyticsStorageChecked}
         >
           คุกกี้ประเภทนี้จะทำการเก็บข้อมูลการใช้งานเว็บไซต์ของคุณ เพื่อเป็นประโยชน์ในการวัดผล
           ปรับปรุงและพัฒนาประสบการณ์ที่ดีในการใช้งานเว็บไซต์
           ถ้าหากท่านไม่ยินยอมให้เราใช้คุกกี้นี้เราจะไม่สามารถวัดผล ปรังปรุงและพัฒนาเว็บไซต์ได้
         </SettingBlock>
-        <Button onClick={handleClose} variant="contained" fullWidth>
+        <Button onClick={handleConfirm} variant="contained" fullWidth>
           ยืนยัน
         </Button>
       </DialogContent>

--- a/apps/cugetreg-web/src/common/components/CookieBanner/index.tsx
+++ b/apps/cugetreg-web/src/common/components/CookieBanner/index.tsx
@@ -11,10 +11,10 @@ import { Container, FixedContainer } from './styled'
 export const CookieBanner = () => {
   const {
     consents,
-    openBanner,
-    openSettings,
-    setOpenSettings,
-    setOpenBanner,
+    bannerOpen,
+    settingsOpen,
+    setBannerOpen,
+    setSettingsOpen,
     setConsents,
     submitConsents,
   } = useConsentsStore()
@@ -24,12 +24,12 @@ export const CookieBanner = () => {
   }
 
   const handleOpenSettings = () => {
-    setOpenSettings(true)
+    setSettingsOpen(true)
   }
 
   const handleCloseSettings = () => {
-    setOpenBanner(false)
-    setOpenSettings(false)
+    setBannerOpen(false)
+    setSettingsOpen(false)
   }
 
   const handleConsentAll = () => {
@@ -39,12 +39,12 @@ export const CookieBanner = () => {
     }
     setConsents(selectedConsents)
     submitConsents(selectedConsents)
-    setOpenBanner(false)
+    setBannerOpen(false)
   }
 
   return (
     <>
-      {openBanner && (
+      {bannerOpen && (
         <FixedContainer>
           <Container>
             <Typography variant="body1" mb={2}>
@@ -67,7 +67,7 @@ export const CookieBanner = () => {
         </FixedContainer>
       )}
       <CookieSettings
-        open={openSettings}
+        open={settingsOpen}
         onClose={handleCloseSettings}
         consents={consents}
         setConsents={setConsentsSetting}

--- a/apps/cugetreg-web/src/common/components/CookieBanner/index.tsx
+++ b/apps/cugetreg-web/src/common/components/CookieBanner/index.tsx
@@ -28,7 +28,6 @@ export const CookieBanner = () => {
   }
 
   const handleCloseSettings = () => {
-    setBannerOpen(false)
     setSettingsOpen(false)
   }
 

--- a/apps/cugetreg-web/src/common/components/CookieBanner/index.tsx
+++ b/apps/cugetreg-web/src/common/components/CookieBanner/index.tsx
@@ -31,6 +31,10 @@ export const CookieBanner = () => {
     setSettingsOpen(false)
   }
 
+  const handleCloseBanner = () => {
+    setBannerOpen(false)
+  }
+
   const handleConsentAll = () => {
     const selectedConsents: Consents = {
       // [ConsentMode.AD_STORAGE]: true,
@@ -68,6 +72,7 @@ export const CookieBanner = () => {
       <CookieSettings
         open={settingsOpen}
         onClose={handleCloseSettings}
+        onCloseBanner={handleCloseBanner}
         consents={consents}
         setConsents={setConsentsSetting}
         submitConsents={submitConsents}

--- a/apps/cugetreg-web/src/common/components/Footer/components/Banner/index.tsx
+++ b/apps/cugetreg-web/src/common/components/Footer/components/Banner/index.tsx
@@ -21,7 +21,7 @@ import {
 
 export function Banner() {
   const { t } = useTranslation('footer')
-  const { setOpenSettings } = useConsentsStore()
+  const { setSettingsOpen } = useConsentsStore()
 
   return (
     <BannerContainer spacing={[1, 3]}>
@@ -46,7 +46,7 @@ export function Banner() {
         <Link href="/privacy" passHref>
           <PrivacyLink>Privacy Policy</PrivacyLink>
         </Link>
-        <CookieSetting onClick={() => setOpenSettings(true)}>Privacy Preferences</CookieSetting>
+        <CookieSetting onClick={() => setSettingsOpen(true)}>Privacy Preferences</CookieSetting>
       </Stack>
     </BannerContainer>
   )

--- a/apps/cugetreg-web/src/store/consents.ts
+++ b/apps/cugetreg-web/src/store/consents.ts
@@ -7,10 +7,10 @@ import { Consents } from '@web/common/types/consents'
 
 interface ConsentsStoreProps {
   consents: Consents
-  openBanner: boolean
-  openSettings: boolean
-  setOpenBanner: (openBanner: boolean) => void
-  setOpenSettings: (openSettings: boolean) => void
+  bannerOpen: boolean
+  settingsOpen: boolean
+  setBannerOpen: (bannerOpen: boolean) => void
+  setSettingsOpen: (settingsOpen: boolean) => void
   setConsents: (consents: Consents) => void
   submitConsents: (consents?: Consents) => void
 }
@@ -18,12 +18,12 @@ interface ConsentsStoreProps {
 export const useConsentsStore = create<ConsentsStoreProps>((set, get) => {
   const initialConsents = JSON.parse((getCookie(CookieKey.CONSENTS) as string) ?? '{}') as Consents
 
-  const setOpenBanner = (openBanner: boolean) => {
-    set((state) => ({ ...state, openBanner }))
+  const setBannerOpen = (bannerOpen: boolean) => {
+    set((state) => ({ ...state, bannerOpen }))
   }
 
-  const setOpenSettings = (openSettings: boolean) => {
-    set((state) => ({ ...state, openSettings }))
+  const setSettingsOpen = (settingsOpen: boolean) => {
+    set((state) => ({ ...state, settingsOpen }))
   }
 
   const setConsents = (consents: Partial<Consents>) => {
@@ -41,10 +41,10 @@ export const useConsentsStore = create<ConsentsStoreProps>((set, get) => {
 
   return {
     consents: initialConsents || {},
-    openBanner: !Object.keys(initialConsents).length,
-    openSettings: false,
-    setOpenBanner,
-    setOpenSettings,
+    bannerOpen: !Object.keys(initialConsents).length,
+    settingsOpen: false,
+    setBannerOpen,
+    setSettingsOpen,
     setConsents,
     submitConsents,
   }


### PR DESCRIPTION
## Why did you create this PR
See #377

## What did you do
Changed the consent banner and dialog behavior as follow:
- Opening the settings dialog no longer closes the banner
- Clicking confirm in the dialog will save the changes and close the banner

## Demo
[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist
- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!-- 
## Related links
-
-->
 
