### PR TITLE
[Hotfix] Change trigger event for master branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,7 @@
 name: Deploy
 on:
-  workflow_dispatch:
   push:
-    branches: [beta, dev]
+    branches: [master, beta, dev]
 
 permissions:
   actions: read


### PR DESCRIPTION
## Why did you create this PR

- เนื่องจาก workflow_dispatch ไม่มี `github.event.before` ทำให้ check affacted กับ commit ก่อนหน้าไม่ได้
- ซึ่งเราอาาจะแก้ได้โดยใช้ git CLI ในการหา commit sha ก่อนหน้า แต่ก็จะมีกรณี ถ้าเรา merge จาก beta / hotfix เข้า master เยอะ แล้ว dispatch ทีเดียวแล้วจะเทียบกับ commit ไหน (จะหายังไง)
- ซึ่งจากข้อ 2 เราอาจจะใช้ git tag ในการ detect commit ที่มี tag ล่าสุดได้ ด้วย `git show-ref --tags | tail -1 | awk '{print $1}' ` แต่ก็จะซับซ้อนมากขึ้น ซึ่งเรื่อง tag เดี๋ยวมาทำอีกที 

## What did you do

- จากทั้งหมดที่กล่าวมา เลยคิดว่า เปลี่ยน workflow_dispatch เป็น push event สำหรับ master branch น่าจะง่ายที่สุดในเวลานี้แล้ว

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
